### PR TITLE
Sinatra webhook

### DIFF
--- a/lib/pushpop.rb
+++ b/lib/pushpop.rb
@@ -35,6 +35,12 @@ module Pushpop
       @web ||= Web.new
     end
 
+    def start_webserver
+      if @web
+        @web.app.run!
+      end
+    end
+
     # for jobs and steps
     def random_name
       (0...8).map { (65 + rand(26)).chr }.join
@@ -53,16 +59,11 @@ module Pushpop
       self.jobs.map &:schedule
     end
 
-    def start_webserver
-      if @web
-        @web.start
-      end
-    end
-
     def start_clock
-      Thread.new do
+      t = Thread.new do
         Clockwork.manager.run
       end
+      #t.join
     end
 
     def require_file(file = nil)

--- a/lib/pushpop.rb
+++ b/lib/pushpop.rb
@@ -4,6 +4,7 @@ require 'pushpop/version'
 require 'pushpop/job'
 require 'pushpop/step'
 require 'pushpop/cli'
+require 'pushpop/web'
 
 module Pushpop
   class << self
@@ -30,6 +31,10 @@ module Pushpop
       @@jobs
     end
 
+    def web
+      @web ||= Web.new
+    end
+
     # for jobs and steps
     def random_name
       (0...8).map { (65 + rand(26)).chr }.join
@@ -46,6 +51,12 @@ module Pushpop
 
     def schedule
       self.jobs.map &:schedule
+    end
+
+    def start_webserver
+      if @web
+        @web.start
+      end
     end
 
     def load_plugin(name)

--- a/lib/pushpop.rb
+++ b/lib/pushpop.rb
@@ -59,6 +59,29 @@ module Pushpop
       end
     end
 
+    def start_clock
+      Thread.new do
+        Clockwork.manager.run
+      end
+    end
+
+    def require_file(file = nil)
+      if file
+        if File.directory?(file)
+          Dir.glob("#{file}/**/*.rb").each { |file|
+            load "#{Dir.pwd}/#{file}"
+          }
+        else
+          load file
+        end
+      else
+        Dir.glob("#{Dir.pwd}/jobs/**/*.rb").each { |file|
+          load file
+        }
+      end
+    end
+    alias :load_jobs :require_file 
+
     def load_plugin(name)
       load "#{File.expand_path("../plugins/#{name}", __FILE__)}.rb"
     end

--- a/lib/pushpop.rb
+++ b/lib/pushpop.rb
@@ -36,8 +36,15 @@ module Pushpop
     end
 
     def start_webserver
-      if @web
-        @web.app.run!
+      # If we start this thread with no routes, it will throw off the all_waits listener
+      # and we don't want to start the web server willy nilly, because it looks weird
+      # on the CLI interface
+      if web.routes.length > 0
+        Thread.new do
+          @web.app.run!
+        end
+      else
+        false
       end
     end
 
@@ -60,10 +67,9 @@ module Pushpop
     end
 
     def start_clock
-      t = Thread.new do
+      Thread.new do
         Clockwork.manager.run
       end
-      #t.join
     end
 
     def require_file(file = nil)

--- a/lib/pushpop/cli.rb
+++ b/lib/pushpop/cli.rb
@@ -24,7 +24,7 @@ module Pushpop
 
     def describe_jobs
       Dotenv.load
-      require_file(options[:file])
+      Pushpop.require_file(options[:file])
       Pushpop.jobs.tap do |jobs|
         jobs.each do |job|
           puts job.name
@@ -38,7 +38,7 @@ module Pushpop
 
     def run_jobs_once
       Dotenv.load
-      require_file(options[:file])
+      Pushpop.require_file(options[:file])
       Pushpop.run
     end
 
@@ -48,32 +48,11 @@ module Pushpop
 
     def run_jobs
       Dotenv.load
-      require_file(options[:file])
+      Pushpop.require_file(options[:file])
       Pushpop.schedule
-      t = Thread.new do
-        Clockwork.manager.run
-      end
+      Pushpop.start_clock
       Pushpop.start_webserver
     end
-
-    private
-
-    def require_file(file)
-      if file
-        if File.directory?(file)
-          Dir.glob("#{file}/**/*.rb").each { |file|
-            load "#{Dir.pwd}/#{file}"
-          }
-        else
-          load file
-        end
-      else
-        Dir.glob("#{Dir.pwd}/jobs/**/*.rb").each { |file|
-          load file
-        }
-      end
-    end
-
   end
 end
 

--- a/lib/pushpop/cli.rb
+++ b/lib/pushpop/cli.rb
@@ -50,7 +50,10 @@ module Pushpop
       Dotenv.load
       require_file(options[:file])
       Pushpop.schedule
-      Clockwork.manager.run
+      t = Thread.new do
+        Clockwork.manager.run
+      end
+      Pushpop.start_webserver
     end
 
     private

--- a/lib/pushpop/job.rb
+++ b/lib/pushpop/job.rb
@@ -19,6 +19,7 @@ module Pushpop
 
     attr_accessor :name
     attr_accessor :period
+    attr_accessor :webhook_url
     attr_accessor :every_options
     attr_accessor :steps
 
@@ -32,6 +33,11 @@ module Pushpop
     def every(period, options={})
       self.period = period
       self.every_options = options
+    end
+
+    def webhook(url)
+      self.webhook_url = url
+      Pushpop.web.add_route(url, self)
     end
 
     def step(name=nil, plugin=nil, &block)
@@ -51,9 +57,12 @@ module Pushpop
     end
 
     def schedule
-      raise 'Set job period via "every"' unless self.period
-      Clockwork.manager.every(period, name, every_options) do
-        run
+      raise 'Set job period via "every"' unless self.period || self.webhook_url
+
+      if self.period
+        Clockwork.manager.every(period, name, every_options) do
+          run
+        end
       end
     end
 

--- a/lib/pushpop/version.rb
+++ b/lib/pushpop/version.rb
@@ -1,3 +1,3 @@
 module Pushpop
-  VERSION = '0.2'
+  VERSION = '0.3'
 end

--- a/lib/pushpop/web.rb
+++ b/lib/pushpop/web.rb
@@ -1,4 +1,5 @@
 require 'sinatra/base'
+require 'json'
 
 module Pushpop
   class Web
@@ -13,7 +14,20 @@ module Pushpop
 
     def add_route(url, job)
       runner = lambda do
-        job.run
+        response = self.instance_eval(&job.webhook_proc)
+
+        if response
+          {
+            status: 'success',
+            job: job.name
+          }.to_json
+        else
+          {
+            status: 'failed',
+            job: job.name,
+            message: 'webhook step did not [ass'
+          }.to_json
+        end
       end
 
       if url[0] != '/'

--- a/lib/pushpop/web.rb
+++ b/lib/pushpop/web.rb
@@ -8,6 +8,10 @@ module Pushpop
       Sinatra::Application
     end
 
+    def routes
+      @routes ||= []
+    end
+
     def add_route(url, job)
       runner = lambda do
         response = self.instance_eval(&job.webhook_proc)
@@ -30,11 +34,11 @@ module Pushpop
         url = "/#{url}"
       end
       
-      puts "adding route #{url}"
-
       Sinatra::Application.get  url, &runner
       Sinatra::Application.post url, &runner
       Sinatra::Application.put  url, &runner
+
+      routes.push(url)
     
     end
   end

--- a/lib/pushpop/web.rb
+++ b/lib/pushpop/web.rb
@@ -13,6 +13,13 @@ module Pushpop
     end
 
     def add_route(url, job)
+
+      if url[0] != '/'
+        url = "/#{url}"
+      end
+
+      raise "Route #{url} is already set up as a webhook" if routes.include?(url)
+
       runner = lambda do
         response = self.instance_eval(&job.webhook_proc)
 
@@ -28,10 +35,6 @@ module Pushpop
             message: 'webhook step did not pass'
           }.to_json
         end
-      end
-
-      if url[0] != '/'
-        url = "/#{url}"
       end
       
       Sinatra::Application.get  url, &runner

--- a/lib/pushpop/web.rb
+++ b/lib/pushpop/web.rb
@@ -1,0 +1,29 @@
+require 'sinatra/base'
+
+module Pushpop
+  class Web
+    
+    def initialize
+      @app = Sinatra.new
+    end
+
+    def start
+      @app.run! unless @app.running?
+    end
+
+    def add_route(url, job)
+      runner = lambda do
+        job.run
+      end
+
+      if url[0] != '/'
+        url = "/#{url}"
+      end
+
+      @app.get  url, &runner
+      @app.post url, &runner
+      @app.put  url, &runner
+    
+    end
+  end
+end

--- a/lib/pushpop/web.rb
+++ b/lib/pushpop/web.rb
@@ -3,13 +3,9 @@ require 'json'
 
 module Pushpop
   class Web
-    
-    def initialize
-      @app = Sinatra.new
-    end
 
-    def start
-      @app.run! unless @app.running?
+    def app
+      Sinatra::Application
     end
 
     def add_route(url, job)
@@ -25,7 +21,7 @@ module Pushpop
           {
             status: 'failed',
             job: job.name,
-            message: 'webhook step did not [ass'
+            message: 'webhook step did not pass'
           }.to_json
         end
       end
@@ -33,10 +29,12 @@ module Pushpop
       if url[0] != '/'
         url = "/#{url}"
       end
+      
+      puts "adding route #{url}"
 
-      @app.get  url, &runner
-      @app.post url, &runner
-      @app.put  url, &runner
+      Sinatra::Application.get  url, &runner
+      Sinatra::Application.post url, &runner
+      Sinatra::Application.put  url, &runner
     
     end
   end

--- a/pushpop.gemspec
+++ b/pushpop.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "clockwork"
   s.add_dependency "thor"
+  s.add_dependency "sinatra"
   s.add_dependency "dotenv"
 
   s.files         = `git ls-files`.split("\n")

--- a/spec/pushpop/web_spec.rb
+++ b/spec/pushpop/web_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Pushpop::Web do
+  web = nil
+
+  before(:each) do
+    web = Pushpop::Web.new
+  end
+
+  it 'returns a Sinatra Application' do
+    expect(web.app).to equal(Sinatra::Application)
+  end
+
+  describe 'routes' do
+    it 'is an array' do
+      expect(web.routes.class).to equal(Array)
+    end
+    
+    it 'is empty by default' do
+      expect(web.routes.length).to equal(0)
+    end
+
+    it 'gets filled with new routes' do
+      web.add_route('/test', Proc.new{})
+
+      expect(web.routes.length).to equal(1)
+      expect(web.routes[0]).to eq('/test')
+    end
+  end
+
+  describe 'add_route' do
+
+    before(:each) do
+      Sinatra::Application.reset!
+    end
+
+    it 'raises an error for duplicate routes' do
+      empty_proc = Proc.new{}
+
+      web.add_route('/test', empty_proc)
+      expect{web.add_route('/test', empty_proc)}.to raise_error
+    end 
+
+    it 'creates GET, POST, and PUT endpoints' do
+      web.add_route('/test', Proc.new{})
+
+      ['GET', 'POST', 'PUT'].each do |method|
+        expect(web.app.routes.include?(method)).to be_truthy
+        expect(web.app.routes[method].length).to equal(1)
+        expect(web.app.routes[method][0][0].match('/test').length).to equal(1)
+      end
+    end
+  end
+end

--- a/spec/pushpop_spec.rb
+++ b/spec/pushpop_spec.rb
@@ -8,6 +8,9 @@ describe 'job' do
 end
 
 describe Pushpop do
+  before(:each) do
+    Pushpop.web.instance_variable_set(:@routes, [])    
+  end
 
   describe 'add_job' do
     it 'adds a job to the list' do
@@ -20,6 +23,33 @@ describe Pushpop do
   describe 'random_name' do
     it 'is 8 characters and alphanumeric' do
       expect(Pushpop.random_name).to match(/^\w{8}$/)
+    end
+  end
+
+  describe 'clock' do
+    it 'starts clock in a thread' do
+      t = Pushpop.start_clock
+      expect(t.class).to be(Thread)
+
+      t.exit
+    end
+  end
+
+  describe 'web' do
+    it 'gets or creates an instance of Web' do
+      expect(Pushpop.web.class).to be(Pushpop::Web)
+    end
+
+    it 'does not start the web app if no routes are defined' do
+      expect(Pushpop.start_webserver).to be_falsey
+    end
+
+    it 'starts the web app in a thread' do
+      Pushpop.web.add_route('/test', Proc.new{})
+      t = Pushpop.start_webserver
+      expect(t.class).to be(Thread)
+
+      t.exit
     end
   end
 


### PR DESCRIPTION
## What is this
This _should_ add support for webhook-initiated jobs. Webhooks would allow us to start jobs immediately when an event happens, rather than polling for changes every N minutes.

Internally the web server is a very basic Sinatra app. Every time the user adds a webhook job, we register a new route with sinatra - we listen to GET, PUT, and POST requests (all have an identical handler).

The user will be able to define the route for the webhook to whatever they want. This should also probably have some concept of authentication (HTTP basic, or maybe a secret GET param key).

## How the user initiates it

Webhook jobs are created by using `webhook` instead of `every`. `webhook` should be called with a path and a block - the block will get called whenever a request is made to that path, and it will execute in the sinatra request's scope. That's helpful, because things like `params` can be accessed right there.

```ruby
job do
  
  webhook '/path' do
    if params['secret_key'] == 'abcdef'
      params['data']
    else
      false
    end
  end

  step 'test' do
    puts 'test'
  end
end
```


### Starting with rackup, thin, etc.
config.ru
```ruby
require 'pushpop'

Pushpop.load_jobs # This loads everything in /jobs... The user can pass a specific filename here too
Pushpop.schedule # This schedules clock jobs... this can probably be moved into start_clock, actually
Pushpop.start_clock # Starts the actual clockwork manager in a new thread

run Pushpop.web.app # Starts the sinatra app
```

Then just run:
`rackup`
or
`thin start`

### Starting with unicorn

`config.ru`
```ruby
run Pushpop.web.app
```

`unicorn.rb`
``` ruby
require 'pushpop'

worker_processes 2 # set to whatever you want

Pushpop.load_jobs # This loads everything in /jobs... The user can pass a specific filename here too
Pushpop.schedule # This schedules clock jobs... this can probably be moved into start_clock, actually
Pushpop.start_clock # Starts the actual clockwork manager in a new thread
```

Then run:
`unicorn -c unicorn.rb`

### Triggering
Webhooks can be hit very simply

```bash
cURL localhost:4567/path
```
*PUT, POST, GET are all supported*

## Scary Threads
I don't know a whole ton about threading in ruby, so this makes me nervous... I had to move Clockwork into its own separate thread. If you know anything about threading in ruby (also, thread limits on Heroku), please let me know if I'm being dumb.

## Dreaming
- We could probably expose the sinatra app in a fairly simple way, so that users could build more things on the web server. This would make building pushpop-powered dashboards (similar to PingPong) fairly easy