### PR TITLE
Disallow duplicate step names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 bundler_args: --without development
 
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.1
   - 2.2.2
   - 2.4.0

--- a/lib/pushpop.rb
+++ b/lib/pushpop.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'clockwork'
+require 'pushpop/exceptions'
 require 'pushpop/version'
 require 'pushpop/job'
 require 'pushpop/step'

--- a/lib/pushpop/exceptions.rb
+++ b/lib/pushpop/exceptions.rb
@@ -1,0 +1,12 @@
+module Pushpop
+  class Error < RuntimeError
+  end
+
+  class DuplicateStepNameError < Error
+    def initialize(step)
+      @step = step
+      msg = "Duplicate step name '#{step.name}'."
+      super(msg)
+    end
+  end
+end

--- a/lib/pushpop/job.rb
+++ b/lib/pushpop/job.rb
@@ -59,6 +59,13 @@ module Pushpop
     end
 
     def add_step(step)
+      # Ensure we don't have duplicate step names.
+      self.steps.each do |check_step|
+        if check_step.name == step.name
+          raise Pushpop::DuplicateStepNameError.new(step)
+        end
+      end
+
       self.steps.push(step)
     end
 

--- a/lib/pushpop/version.rb
+++ b/lib/pushpop/version.rb
@@ -1,3 +1,3 @@
 module Pushpop
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/pushpop/job_spec.rb
+++ b/spec/pushpop/job_spec.rb
@@ -97,6 +97,44 @@ describe Pushpop::Job do
     end
   end
 
+  describe '#add_step' do
+    let(:job) { empty_job }
+    let(:empty_proc) { Proc.new {} }
+
+    context 'no existing steps' do
+      it 'adds a step' do
+        step = Pushpop::Step.new('step1', 'blaz', &empty_proc)
+        job.add_step(step)
+
+        expect(job.steps.length).to eq(1)
+        expect(job.steps.first.name).to eq(step.name)
+      end
+    end
+
+    context 'with existing steps' do
+      let(:step) { Pushpop::Step.new('step1', 'blaz', &empty_proc) }
+
+      before(:each) do
+        job.add_step(step)
+      end
+
+      it 'adds a step' do
+        step_two = Pushpop::Step.new('step2', 'blaz', &empty_proc)
+        job.add_step(step_two)
+
+        expect(job.steps.length).to eq(2)
+        expect(job.steps.first.name).to eq(step.name)
+        expect(job.steps.last.name).to eq(step_two.name)
+      end
+
+      it 'raises for duplicate step names' do
+        expect {
+          job.add_step(step)
+        }.to raise_error(Pushpop::DuplicateStepNameError)
+      end
+    end
+  end
+
   describe '#run' do
     it 'calls each step with the response to the previous' do
       job = Pushpop::Job.new('foo') do


### PR DESCRIPTION
- Throw an exception if we get a duplicate name.
- Added some new ruby versions to test against
- Removed deprecated ruby versions (travis doesn't like them)

This addresses #20 